### PR TITLE
RGG-40: Student work release field added to entry submission form

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .vscode/
+.DS_Store

--- a/backend/db/migrations/20171116292217-create-entry.js
+++ b/backend/db/migrations/20171116292217-create-entry.js
@@ -60,6 +60,9 @@ export function up (queryInterface, Sequelize) {
     comment: {
       type: Sequelize.TEXT
     },
+    distributionAllowed: {
+      type: Sequelize.BOOLEAN
+    },
     moreCopies: {
       allowNull: false,
       defaultValue: false,

--- a/backend/models/entry.js
+++ b/backend/models/entry.js
@@ -9,15 +9,55 @@ import sequelize from '../config/sequelize'
 import { IMAGE_ENTRY, VIDEO_ENTRY, OTHER_ENTRY } from '../constants'
 
 const Entry = sequelize.define('entry', {
-  showId: {
+  academicProgram: {
+    allowNull: true,
+    type: DataTypes.TEXT
+  },
+  awardWon: {
+    type: DataTypes.TEXT
+  },
+  comment: {
+    type: DataTypes.TEXT
+  },
+  distributionAllowed: {
+    type: DataTypes.BOOLEAN,
+  },
+  entryType: {
+    allowNull: false,
+    type: DataTypes.INTEGER
+  },
+  entryId: {
+    allowNull: false,
+    type: DataTypes.INTEGER
+  },
+  excludeFromJudging: {
+    allowNull: false,
+    type: DataTypes.BOOLEAN,
+    defaultValue: false
+  },
+  forSale: {
+    allowNull: false,
+    defaultValue: false,
+    type: DataTypes.BOOLEAN
+  },
+  groupId: {
     allowNull: true,
     type: DataTypes.INTEGER,
     references: {
-      model: 'shows',
+      model: 'groups',
       key: 'id'
     },
     onDelete: 'cascade',
     onUpdate: 'cascade'
+  },
+  invited: {
+    allowNull: true,
+    type: DataTypes.BOOLEAN
+  },
+  moreCopies: {
+    allowNull: false,
+    defaultValue: false,
+    type: DataTypes.BOOLEAN
   },
   // The id of the portfolio the entry is associated with (only if showId is null)
   portfolioId: {
@@ -25,6 +65,16 @@ const Entry = sequelize.define('entry', {
     type: DataTypes.INTEGER,
     references: {
       model: 'portfolios',
+      key: 'id'
+    },
+    onDelete: 'cascade',
+    onUpdate: 'cascade'
+  },
+  showId: {
+    allowNull: true,
+    type: DataTypes.INTEGER,
+    references: {
+      model: 'shows',
       key: 'id'
     },
     onDelete: 'cascade',
@@ -40,61 +90,14 @@ const Entry = sequelize.define('entry', {
     onDelete: 'cascade',
     onUpdate: 'cascade'
   },
-  groupId: {
-    allowNull: true,
-    type: DataTypes.INTEGER,
-    references: {
-      model: 'groups',
-      key: 'id'
-    },
-    onDelete: 'cascade',
-    onUpdate: 'cascade'
-  },
-  entryType: {
-    allowNull: false,
-    type: DataTypes.INTEGER
-  },
-  entryId: {
-    allowNull: false,
-    type: DataTypes.INTEGER
-  },
   title: {
     type: DataTypes.STRING,
     defaultValue: 'Untitled',
     allowNull: false
   },
-  comment: {
-    type: DataTypes.TEXT
-  },
-  moreCopies: {
-    allowNull: false,
-    defaultValue: false,
-    type: DataTypes.BOOLEAN
-  },
-  forSale: {
-    allowNull: false,
-    defaultValue: false,
-    type: DataTypes.BOOLEAN
-  },
-  awardWon: {
-    type: DataTypes.TEXT
-  },
-  invited: {
-    allowNull: true,
-    type: DataTypes.BOOLEAN
-  },
   yearLevel: {
     allowNull: true,
     type: DataTypes.TEXT
-  },
-  academicProgram: {
-    allowNull: true,
-    type: DataTypes.TEXT
-  },
-  excludeFromJudging: {
-    allowNull: false,
-    type: DataTypes.BOOLEAN,
-    defaultValue: false
   },
   createdAt: {
     allowNull: false,

--- a/backend/schema.js
+++ b/backend/schema.js
@@ -111,6 +111,7 @@ input VoteInput {
 
 interface Entry {
     id: ID!
+    distributionAllowed: Boolean
     group: Group
     student: User
     show: Show
@@ -130,6 +131,7 @@ interface Entry {
 
 input EntryInput {
     group: GroupInput
+    distributionAllowed: Boolean
     studentUsername: String
     showId: Int
     portfolioId: Int
@@ -157,6 +159,7 @@ input EntryUpdate {
 type Photo implements Entry {
     id: ID!
     group: Group
+    distributionAllowed: Boolean
     student: User
     show: Show
     portfolioId: Int
@@ -190,6 +193,7 @@ type Video implements Entry {
     id: ID!
     group: Group
     student: User
+    distributionAllowed: Boolean
     show: Show
     portfolioId: Int
     title: String
@@ -216,6 +220,7 @@ input VideoInput {
 type OtherMedia implements Entry {
     id: ID!
     group: Group
+    distributionAllowed: Boolean
     student: User
     show: Show
     portfolioId: Int

--- a/frontend/src/Admin/components/ShowSubmissionDetails.js
+++ b/frontend/src/Admin/components/ShowSubmissionDetails.js
@@ -128,6 +128,7 @@ class ShowSubmissionDetails extends Component {
       yearLevel: PropTypes.string.isRequired,
       academicProgram: PropTypes.string.isRequired,
       forSale: PropTypes.bool.isRequired,
+      distributionAllowed: PropTypes.bool,
       moreCopies: PropTypes.bool.isRequired,
       entryType: PropTypes.string.isRequired,
       // For Photo or Other Entries
@@ -200,6 +201,8 @@ class ShowSubmissionDetails extends Component {
             ) : null}
             <dt>Score</dt>
             <dd>{submission.score.toFixed(3)}</dd>
+            <dt>Distribution Allowed?</dt>
+            <dd>{submission.distributionAllowed ? 'Yes' : 'No'}</dd>
             <dt>Invited?</dt>
             <dd>{submission.invited ? 'Yes' : 'No'}</dd>
             {renderSubmissionByType(submission)}

--- a/frontend/src/Admin/queries/show.graphql
+++ b/frontend/src/Admin/queries/show.graphql
@@ -19,6 +19,7 @@ query Show($id: ID!) {
     entries {
       id
       title
+      distributionAllowed
       comment
       entryType
       invited

--- a/frontend/src/Admin/queries/showForPrinting.graphql
+++ b/frontend/src/Admin/queries/showForPrinting.graphql
@@ -9,6 +9,7 @@ query Show($id: ID!) {
       entryType
       invited
       forSale
+      distributionAllowed
       moreCopies
       excludeFromJudging
       student {

--- a/frontend/src/Student/components/SubmissionForm.js
+++ b/frontend/src/Student/components/SubmissionForm.js
@@ -12,6 +12,7 @@ import SubmitAsGroupRadio from './SubmitAsGroupRadio'
 import HomeTownInput from './HomeTownInput'
 import DisplayNameInput from './DisplayNameInput'
 import FileUploadInput from './FileUploadInput'
+import InfoPopover from '../../shared/components/InfoPopover'
 
 const Header = styled.h1`
   margin-bottom: 10px;
@@ -30,7 +31,7 @@ class SubmissionForm extends Component {
     previewImage: {}
   }
 
-  constructor (props) {
+  constructor(props) {
     super(props)
     this.state = { showModal: false }
     // Clear any uploaded files for the next time a user views the form.
@@ -55,13 +56,13 @@ class SubmissionForm extends Component {
   }
 
   // Create the object of input values and submit the entry
-  submitForm (values) {
+  submitForm(values) {
     const inputs = this.buildInput(values)
     this.createEntry(inputs, values)
   }
 
   // Create the object containing all input values for submission
-  buildInput (values) {
+  buildInput(values) {
     return {
       entry: {
         group: values.submittingAsGroup === 'yes'
@@ -70,6 +71,7 @@ class SubmissionForm extends Component {
             participants: values.groupParticipants
           } : null,
         displayName: values.displayName,
+        distributionAllowed: values.distributionAllowed === 'yes',
         hometown: values.submittingAsGroup === 'no' ? values.hometown : null,
         studentUsername: values.submittingAsGroup === 'no' ? this.props.user.username : null,
         showId: this.props.forShow.id,
@@ -92,7 +94,7 @@ class SubmissionForm extends Component {
   }
 
   // Create the validation schema for the form ui
-  buildValidationSchema () {
+  buildValidationSchema() {
     const isRequiredString = yup.string().required('Required') // required string field
     const isRequiredNumber = yup.number().required('Required') // required number field
     const radioValues = yup.string().required('Required').oneOf(['yes', 'no']) // radio values
@@ -102,6 +104,7 @@ class SubmissionForm extends Component {
       academicProgram: isRequiredString,
       yearLevel: isRequiredString,
       title: isRequiredString,
+      distributionAllowed: radioValues,
       submittingAsGroup: radioValues,
       forSale: radioValues,
       moreCopies: radioValues,
@@ -124,11 +127,11 @@ class SubmissionForm extends Component {
   }
 
   // Create an entry, show the success modal, and then go to the dashboard
-  createEntry (input, values) {
+  createEntry(input, values) {
     const cleanInput = Object.fromEntries(Object.entries(input).filter(([_, v]) => v != null))
     this.props.create(cleanInput)
       .then(() => {
-        if (values.submittingAsGroup === 'no') 
+        if (values.submittingAsGroup === 'no')
           this.props.handleHometown(values.hometown)
         this.props.handleDisplayName(values.displayName)
       })
@@ -138,8 +141,21 @@ class SubmissionForm extends Component {
       .catch(err => this.props.handleError(err.message))
   }
 
-  render () {
+  render() {
     const validation = this.buildValidationSchema()
+    const workReleaseContent = (
+      <React.Fragment>
+        <p>
+          I, for consideration received, do hereby grant to Rochester Institute of Technology (“RIT”), and its respective individual employees, directors, officers, agents, representatives, successors and assigns, the nonexclusive, worldwide, absolute and irrevocable right and unrestricted permission, and without further notice to me or any other or further consent or authorization from me, to use and reproduce my Work(s) being submitted here.
+        </p>
+        <p>
+          I warrant and represent that I am the owner and/or creator of the Work(s) described above and that I have the legal right and authority to enter into this Agreement for purposes of providing this Permission and Release to RIT. I agree that I am entitled to no additional compensation from RIT for use of the Work(s) other than what may have already been given to me upon execution of this Release.
+        </p>
+        <p>
+          I do hereby release RIT, its individual employees, directors, officers, agents, representatives, successors and assigns, now and forever, from any actions, suits, claims, covenants, damages, executions, demands and liabilities which I or my heirs, representatives, successors and assigns ever had, now have or may have arising out of the aforesaid authorization and consent, without limitation, including any claims for libel or alleged misrepresentation of me by virtue of the use of these Work(s).
+        </p>
+      </React.Fragment>
+    );
     return (
       <FormGroup>
         <Fragment>
@@ -154,6 +170,7 @@ class SubmissionForm extends Component {
               mediaType: this.props.type === 'Photo' ? '' : null,
               horizDimInch: this.props.type === 'Photo' ? '' : null,
               vertDimInch: this.props.type === 'Photo' ? '' : null,
+              distributionAllowed: 'no',
               forSale: 'no',
               moreCopies: 'no',
               path: this.props.type !== 'Video' ? '' : null,
@@ -379,6 +396,34 @@ class SubmissionForm extends Component {
                           {this.renderErrors(touched, errors, 'moreCopies')}
                         </FormGroup>
                       ) : null}
+                      <FormGroup>
+                        <Label>
+                          <span className='d-inline-flex align-items-center'>
+                            <span className='mr-2'>I have read and agree to the terms.</span>
+
+                            <InfoPopover id='distributionAllowedInfo' title='PERMISSION AND RELEASE TO USE WORK(S)' content={workReleaseContent} />
+                          </span>
+
+                        </Label>
+                        {['no', 'yes'].map((value, idx) => { // rendering no and yes radios
+                          return (
+                            <FormGroup check key={idx}>
+                              <Label check>
+                                <Field
+                                  type='radio'
+                                  id='distributionAllowed'
+                                  name='distributionAllowed'
+                                  value={value}
+                                  required
+                                  checked={values.distributionAllowed === value}
+                                />
+                                <span className='ml-2'>{value}</span>
+                              </Label>
+                            </FormGroup>
+                          )
+                        })}
+                        {this.renderErrors(touched, errors, 'forSale')}
+                      </FormGroup>
                       {this.props.type !== 'Video' ? <FileUploadInput
                         accept='image/jpeg'
                         errors={errors}

--- a/frontend/src/shared/components/InfoPopover.js
+++ b/frontend/src/shared/components/InfoPopover.js
@@ -1,0 +1,37 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button, Popover, PopoverHeader, PopoverBody } from 'reactstrap';
+
+// Fontawesome icons
+import FontAwesomeIcon from '@fortawesome/react-fontawesome'
+import FaInfo from '@fortawesome/fontawesome-free-solid/faInfo';
+
+const InfoPopover = (props) => {
+    const [popoverOpen, setPopoverOpen] = useState(false);
+
+    const toggle = () => setPopoverOpen(!popoverOpen);
+
+    return (
+        <div>
+            <Button id={props.id} type="button" color="link" onClick={toggle} className="p-0">
+                <FontAwesomeIcon icon={FaInfo} size='1x' />
+            </Button>
+            <Popover placement="bottom" isOpen={popoverOpen} target={props.id} toggle={toggle}>
+                { /* Only render the header if a title was passed */}
+                {props.title ? (<PopoverHeader>{props.title}</PopoverHeader>) : null}
+                <PopoverBody>{props.content}</PopoverBody>
+            </Popover>
+        </div>
+    );
+}
+
+InfoPopover.propTypes = {
+    /* id value for the popover */
+    id: PropTypes.string.isRequired,
+    /* Title of the popover container */
+    title: PropTypes.string,
+    /* Content rendered in the popover. Can be text or JSX */
+    content: PropTypes.any
+}
+
+export default InfoPopover;


### PR DESCRIPTION
# Backend
- Added a boolean field `distributionAllowed` for tracking which entries students have authorized for RIT to distribute
- Updated Entry migration to create the new field in the database table
- Refactored GraphQL Schema adding the `distributionAllowed` filed to the entry interface and input along with the photo, video, and other media entry types
# Frontend
- Updated Admin GraphQL queries to query for the `distributionAllowed` field
- Updated Admin ShowSubmissionDetails component to display the value of the `distributionAllowed`
- Added a field for `distributionAllowed` to the SubmissionForm along with an info button